### PR TITLE
Add constants for region and size slugs

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -571,7 +571,7 @@ class Droplet(BaseAPI):
 
     def get_events(self):
         """
-            A helper function for backwards compatability.
+            A helper function for backwards compatibility.
             Calls get_actions()
         """
         return self.get_actions()

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -21,17 +21,6 @@ class BadSSHKeyFormat(DropletError):
     pass
 
 
-512MB = '512mb'
-1GB = '1gb'
-2GB = '2gb'
-4GB = '4gb'
-8GB = '8gb'
-16GB = '16gb'
-32GB = '32gb'
-48GB = '48gb'
-64GB = '64gb'
-
-
 class Droplet(BaseAPI):
     """"Droplet management
 

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -21,6 +21,17 @@ class BadSSHKeyFormat(DropletError):
     pass
 
 
+512MB = '512mb'
+1GB = '1gb'
+2GB = '2gb'
+4GB = '4gb'
+8GB = '8gb'
+16GB = '16gb'
+32GB = '32gb'
+48GB = '48gb'
+64GB = '64gb'
+
+
 class Droplet(BaseAPI):
     """"Droplet management
 

--- a/digitalocean/Region.py
+++ b/digitalocean/Region.py
@@ -2,6 +2,20 @@
 from .baseapi import BaseAPI
 
 
+NYC1 = 'nyc1'
+NYC2 = 'nyc2'
+NYC3 = 'nyc3'
+SFO1 = 'sfo1'
+SFO2 = 'sfo2'
+AMS2 = 'ams2'
+AMS3 = 'ams3'
+LON1 = 'lon1'
+SGP1 = 'sgp1'
+FRA1 = 'fra1'
+TOR1 = 'tor1'
+BLR1 = 'blr1'
+
+
 class Region(BaseAPI):
     def __init__(self, *args, **kwargs):
         self.name = None


### PR DESCRIPTION
I think it'd be nice to have some constants to avoid magic strings. I'm unsure what the correct naming convention would be for the regions (e.g. should it be `SFO1`? `SFO_1`? `SAN_FRANSICO_1`?)

Let me know what you think about this idea

There can also be validation of input against these constants, but I'm not sure whether there should be too much validation by this library, rather than leaving it to the api.